### PR TITLE
Use new --targets API instead of --target-files for meson >= 0.50.0

### DIFF
--- a/mcw/meson.py
+++ b/mcw/meson.py
@@ -75,10 +75,10 @@ class Meson:
     def get_version(self):
         if self.c_version:
             return self.c_version
-        
+
         self.c_version = list(map(int, self.call(['--version']).split('.')))
         return self.c_version
-    
+
     def get_project_name(self):
         if self.c_project_name:
             return self.c_project_name
@@ -105,7 +105,15 @@ class Meson:
             return []
         if id in self.c_target_files:
             return self.c_target_files[id]
+        # Handle the new targets API of 0.50.0
+        if 'target_sources' in target:
+            self.c_target_files[id] = []
+            for i in target['target_sources']:
+                self.c_target_files[id] += i['sources']
+                self.c_target_files[id] += i['generated_sources']
+            return self.c_target_files[id]
 
+        # Handle meson versions before 0.50.0
         self.log('(target) "%s"' % id)
         output = self.call(['introspect', '--target-files', id, self.build_dir])
         self.log('(target files) "%s"' % output)


### PR DESCRIPTION
Meson 0.50.0 will introduce breaking changes to the introspection API. This includes the deprecation/removal of the `--target-files` option (see https://github.com/mesonbuild/meson/pull/4731). There are also other introspection changes which are documented [here](https://github.com/mesonbuild/meson/blob/master/docs/markdown/IDE-integration.md) ([relevant](https://github.com/mesonbuild/meson/blob/master/docs/markdown/snippets/introspect_multiple.md) [release](https://github.com/mesonbuild/meson/blob/master/docs/markdown/snippets/introspect_meson_info.md) [snippets](https://github.com/mesonbuild/meson/blob/master/docs/markdown/snippets/introspect_buildoptions_no_bd.md)).

With this PR mcw will make use of the new `--targets` API and fallback to the old `--target-files` for older meson versions.